### PR TITLE
Point hub to deployed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each project can live in its own folder so heavier apps can evolve independently
 - `index.html` – the lightweight hub that lists every mini project (links, descriptions, CTA badges).
 - `csv-to-json/` – the Dynamo CSV parser running as a self-contained HTML + JS toolpath.
 - `othertools/` – the Next.js workspace that hosts the camera test, signature pad, delayed audio, and audio channel tests. Treat this folder as a standalone Next.js app.
+- `https://other.uft1.com/` – the deployed runtime experience. Every Next.js route (camera, signature, delayed audio, audio test) mirrors what is hosted at that URL, so point your Netlify/hosting config there when you need a full runtime.
 
 ## Developing the Next.js tools
 
@@ -37,6 +38,7 @@ When you’re ready to deploy the Next.js suite, use the same workflow you would
 - Keep root-level assets (static HTML, root CSS, etc.) small so the landing page loads quickly.
 - Use `othertools/` for more complex interactions—it already contains its own `package.json`, `.eslintrc.json`, and Tailwind setup.
 - If you add another static tool, place it in a new folder at the root level and link it from `index.html`.
+- When updating the runtime tools, redeploy `https://other.uft1.com/` so the hosted routes stay in sync with what’s listed on this landing page (see `https://other.uft1.com/camera` as proof-of-deployment).
 
 Happy coding! 🚀
 

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
         </p>
         <div class="hero-links">
           <a href="./csv-to-json/">CSV → JSON converter</a>
-          <a href="./othertools/">Next.js mini tools</a>
+          <a href="https://other.uft1.com/" target="_blank" rel="noreferrer">Next.js mini tools</a>
         </div>
       </header>
 
@@ -220,13 +220,13 @@
             and stereo channel verification. Each widget links to its dedicated route.
           </p>
           <ul class="buckets">
-            <li><a href="./othertools/camera">Camera test</a></li>
-            <li><a href="./othertools/signature">Signature pad</a></li>
-            <li><a href="./othertools/delayed-audio">Delayed audio</a></li>
-            <li><a href="./othertools/audio-test">Audio channel test</a></li>
+            <li><a href="https://other.uft1.com/camera" target="_blank" rel="noreferrer">Camera test</a></li>
+            <li><a href="https://other.uft1.com/signature" target="_blank" rel="noreferrer">Signature pad</a></li>
+            <li><a href="https://other.uft1.com/delayed-audio" target="_blank" rel="noreferrer">Delayed audio</a></li>
+            <li><a href="https://other.uft1.com/audio-test" target="_blank" rel="noreferrer">Audio channel test</a></li>
           </ul>
           <div class="cta-row">
-            <a class="cta" href="./othertools/">Enter Next.js hub ↗</a>
+            <a class="cta" href="https://other.uft1.com/" target="_blank" rel="noreferrer">Enter Next.js hub ↗</a>
             <span class="tag">Next.js / MediaDevices / Web Audio</span>
           </div>
         </article>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Points the hub to the deployed Next.js runtime instead of local paths.
> 
> - Update `index.html` to link `Next.js mini tools` and all tool routes to `https://other.uft1.com/*` (open in new tab with `target="_blank"` and `rel="noreferrer"`)
> - Expand `README.md` with the deployed runtime URL and a note to redeploy `https://other.uft1.com/` to keep hosted routes in sync
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c11d6d64fb168658c98ddf411e9621e1f8306af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->